### PR TITLE
Improve Trivy scan configuration

### DIFF
--- a/.github/workflows/trivy-fs.yml
+++ b/.github/workflows/trivy-fs.yml
@@ -20,6 +20,7 @@ on:
         description: |
           Fail when vulnerabilities are found. This input is ignored when a 'scan_config' is configured. Setting the
           'exit-code' to 1 or higher in the scan config file has the same effect like 'fail_on_issues: true'.
+          DEPRECATED: Use the scan config file and configure the 'exit-code' option instead.
         type: boolean
         required: false
         default: false
@@ -52,6 +53,7 @@ on:
           Comma-separated list of relative paths in repository to one or more '.trivyignore' files - see 
           https://github.com/aquasecurity/trivy-action#inputs (trivyignores). This input is ignored when a 'scan_config'
           is configured. Setting the 'ignorefile' option in the scan config file has the same effect.
+          DEPRECATED: Use the scan config file and configure the 'ignorefile' option instead.
         type: string
         required: false
       scan_path:
@@ -66,6 +68,7 @@ on:
           Defaults to 'trivy-results.sarif' when the scan format is 'sarif'. This input is ignored when a 'scan_config'
           is configured. Setting the 'output' option in the scan config file has the same effect. When an output file is
           explicitly configured with this input, it will be attached to the workflow run.
+          DEPRECATED: Use the scan config file and configure the 'output' option instead.
         type: string
         required: false
       scan_output_format:
@@ -73,6 +76,7 @@ on:
           The output format of the scan results. If the format is 'sarif' (default), the results are automatically
           uploaded to GitHub code scanning. This input is ignored when a 'scan_config' is configured. Setting the
           'format' option in the scan config file has the same effect.
+          DEPRECATED: Use the scan config file and configure the 'format' option instead.
         type: string
         required: false
         default: sarif
@@ -81,6 +85,7 @@ on:
           The output template for the scan results - see https://github.com/aquasecurity/trivy-action#inputs (template).
           This input is ignored when a 'scan_config' is configured. Setting the 'template' option in the scan config
           file has the same effect.
+          DEPRECATED: Use the scan config file and configure the 'template' option instead.
         type: string
         required: false
       scan_severity:
@@ -88,6 +93,7 @@ on:
           The severities of security issues to be reported - see https://github.com/aquasecurity/trivy-action#inputs
           (severity). Defaults to 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'. This input is ignored when a 'scan_config' is
           configured. Setting the 'severity' option in the scan config file has the same effect.
+          DEPRECATED: Use the scan config file and configure the 'severity' option instead.
         type: string
         required: false
       scan_vuln_type:
@@ -95,6 +101,7 @@ on:
           The vulnerability types to be reported - see https://github.com/aquasecurity/trivy-action#inputs (vuln-type).
           This input is ignored when a 'scan_config' is configured. Setting the 'vulnerability.type' option in the scan
           config file has the same effect.
+          DEPRECATED: Use the scan config file and configure the 'vulnerability.type' option instead.
         type: string
         required: false
     outputs:

--- a/.github/workflows/trivy-fs.yml
+++ b/.github/workflows/trivy-fs.yml
@@ -28,14 +28,6 @@ on:
         type: boolean
         required: false
         default: false
-      limit_severities_for_sarif:
-        description: |
-          Limit the severities of the reported issues for SARIF format to the configured severity - see
-          https://github.com/aquasecurity/trivy-action#inputs (limit-severities-for-sarif). Normally the
-          SARIF report contains the issues of all severities. This input can have an influence on the
-          precedence of the action configuration, please see the NOTE above.
-        type: string
-        required: false
       scan_config:
         description: |
           The path to a 'trivy.yaml' config file - see https://github.com/aquasecurity/trivy-action#inputs
@@ -145,7 +137,7 @@ jobs:
           template: ${{ inputs.scan_output_template }}
           vuln-type: ${{ inputs.scan_vuln_type }}
           severity: ${{ inputs.scan_severity }}
-          limit-severities-for-sarif: ${{ inputs.limit_severities_for_sarif }}
+          limit-severities-for-sarif: true
           trivyignores: ${{ inputs.scan_ignores }}
           exit-code: ${{ inputs.fail_on_issues && '1' || '0' }}
 

--- a/.github/workflows/trivy-fs.yml
+++ b/.github/workflows/trivy-fs.yml
@@ -3,13 +3,6 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-# ******** NOTE ********
-# The configuration of the trivy-action (and with that the configuration of THIS workflow) may not behave like expected,
-# because the implementation of the trivy-action takes some unpredictable precedences when working with combinations of
-# SARIF reports, Trivy config file and plain action input parameters. If you experience such unexpected behaviour with
-# your configuration, you may find hints how to solve it having a look at the implementation of the trivy-action,
-# especially https://github.com/aquasecurity/trivy-action/blob/0.11.0/entrypoint.sh#L175-L190.
-
 # Required permissions that must be set in caller workflows (in private repositories):
 # contents:         read      for actions/checkout to fetch code
 # security-events:  write     for github/codeql-action/upload-sarif to upload SARIF results
@@ -24,7 +17,9 @@ on:
         type: string
         required: false
       fail_on_issues:
-        description: Fail when vulnerabilities are found.
+        description: |
+          Fail when vulnerabilities are found. This input is ignored when a 'scan_config' is configured. Setting the
+          'exit-code' to 1 or higher in the scan config file has the same effect like 'fail_on_issues: true'.
         type: boolean
         required: false
         default: false
@@ -33,21 +28,30 @@ on:
           The path to a 'trivy.yaml' config file - see https://github.com/aquasecurity/trivy-action#inputs
           (trivy-config) and https://aquasecurity.github.io/trivy/latest/docs/references/configuration/config-file.
           Using a config file over action inputs provides more configuration options and may lead to cleaner workflow
-          code. A YAML contents of a basic config file may look like this:
-              severity:
-                - MEDIUM
-                - HIGH
-                - CRITICAL
-              vulnerability:
-                type:
-                  - library
-          Please also see the NOTE above to avoid problems due to unpredictable configuration precedences.
+          code. PLEASE NOTE that the trivy-action (and with that the configuration of THIS workflow) ignores the input
+          parameters for scan options when a scan config file is configured. Ensure that all required options are then
+          set in the scan config file. This is a basic scan config file reflecting the default input parameters (with
+          defaults commented out as they can be omitted):
+              format: sarif
+              output: trivy-results.sarif
+              #exit-code: 0
+              #severity:
+              #  - UNKNOWN
+              #  - LOW
+              #  - MEDIUM
+              #  - HIGH
+              #  - CRITICAL
+              #vulnerability:
+              #  type:
+              #    - os
+              #    - library
         type: string
         required: false
       scan_ignores:
         description: |
           Comma-separated list of relative paths in repository to one or more '.trivyignore' files - see 
-          https://github.com/aquasecurity/trivy-action#inputs (trivyignores).
+          https://github.com/aquasecurity/trivy-action#inputs (trivyignores). This input is ignored when a 'scan_config'
+          is configured. Setting the 'ignorefile' option in the scan config file has the same effect.
         type: string
         required: false
       scan_path:
@@ -58,31 +62,39 @@ on:
         default: .
       scan_output_file:
         description: |
-          The output file for the scan results, - see https://github.com/aquasecurity/trivy-action#inputs (output).
-          When an output file be is configured, it will be attached to the workflow run.
+          The output file for the scan results, - see https://github.com/aquasecurity/trivy-action#inputs (output). The
+          Defaults to 'trivy-results.sarif' when the scan format is 'sarif'. This input is ignored when a 'scan_config'
+          is configured. Setting the 'output' option in the scan config file has the same effect. When an output file is
+          explicitly configured with this input, it will be attached to the workflow run.
         type: string
         required: false
       scan_output_format:
         description: |
           The output format of the scan results. If the format is 'sarif' (default), the results are automatically
-          uploaded to GitHub code scanning.
+          uploaded to GitHub code scanning. This input is ignored when a 'scan_config' is configured. Setting the
+          'format' option in the scan config file has the same effect.
         type: string
         required: false
         default: sarif
       scan_output_template:
         description: |
           The output template for the scan results - see https://github.com/aquasecurity/trivy-action#inputs (template).
+          This input is ignored when a 'scan_config' is configured. Setting the 'template' option in the scan config
+          file has the same effect.
         type: string
         required: false
       scan_severity:
         description: |
           The severities of security issues to be reported - see https://github.com/aquasecurity/trivy-action#inputs
-          (severity). Defaults to 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'.
+          (severity). Defaults to 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'. This input is ignored when a 'scan_config' is
+          configured. Setting the 'severity' option in the scan config file has the same effect.
         type: string
         required: false
       scan_vuln_type:
         description: |
           The vulnerability types to be reported - see https://github.com/aquasecurity/trivy-action#inputs (vuln-type).
+          This input is ignored when a 'scan_config' is configured. Setting the 'vulnerability.type' option in the scan
+          config file has the same effect.
         type: string
         required: false
     outputs:
@@ -120,7 +132,7 @@ jobs:
           if [[ -n '${{ inputs.scan_output_file }}' ]]; then
             echo 'output_file=${{ inputs.scan_output_file }}' >> "$GITHUB_OUTPUT"
           elif [[ '${{ inputs.scan_output_format }}' == 'sarif' ]]; then
-            echo 'output_file=trivy-image-results.sarif' >> "$GITHUB_OUTPUT"
+            echo 'output_file=trivy-results.sarif' >> "$GITHUB_OUTPUT"
           elif [[ '${{ inputs.scan_output_format }}' != 'table' ]]; then
             echo "::error title=Configuration Error::'scan_output_format=${{ inputs.scan_output_format }}' requires 'scan_output_file'."
             exit 1

--- a/.github/workflows/trivy-image.yml
+++ b/.github/workflows/trivy-image.yml
@@ -51,14 +51,6 @@ on:
         type: string
         required: false
         default: corretto
-      limit_severities_for_sarif:
-        description: |
-          Limit the severities of the reported issues for SARIF format to the configured severity - see
-          https://github.com/aquasecurity/trivy-action#inputs (limit-severities-for-sarif). Normally the
-          SARIF report contains the issues of all severities. This input can have an influence on the
-          precedence of the action configuration, please see the NOTE above.
-        type: string
-        required: false
       maven_settings:
         description: |
           The (user) 'settings.xml' file to be used for the Maven build. Please note that environment variables
@@ -215,7 +207,7 @@ jobs:
           template: ${{ inputs.scan_output_template }}
           vuln-type: ${{ inputs.scan_vuln_type }}
           severity: ${{ inputs.scan_severity }}
-          limit-severities-for-sarif: ${{ inputs.limit_severities_for_sarif }}
+          limit-severities-for-sarif: true
           trivyignores: ${{ inputs.scan_ignores }}
           exit-code: ${{ inputs.fail_on_issues && '1' || '0' }}
 

--- a/.github/workflows/trivy-image.yml
+++ b/.github/workflows/trivy-image.yml
@@ -25,6 +25,7 @@ on:
         description: |
           Fail when vulnerabilities are found. This input is ignored when a 'scan_config' is configured. Setting the
           'exit-code' to 1 or higher in the scan config file has the same effect like 'fail_on_issues: true'.
+          DEPRECATED: Use the scan config file and configure the 'exit-code' option instead.
         type: boolean
         required: false
         default: false
@@ -81,6 +82,7 @@ on:
           Comma-separated list of relative paths in repository to one or more '.trivyignore' files - see 
           https://github.com/aquasecurity/trivy-action#inputs (trivyignores). This input is ignored when a 'scan_config'
           is configured. Setting the 'ignorefile' option in the scan config file has the same effect.
+          DEPRECATED: Use the scan config file and configure the 'ignorefile' option instead.
         type: string
         required: false
       scan_image_ref:
@@ -95,6 +97,7 @@ on:
           Defaults to 'trivy-results.sarif' when the scan format is 'sarif'. This input is ignored when a 'scan_config'
           is configured. Setting the 'output' option in the scan config file has the same effect. When an output file is
           explicitly configured with this input, it will be attached to the workflow run.
+          DEPRECATED: Use the scan config file and configure the 'output' option instead.
         type: string
         required: false
       scan_output_format:
@@ -102,6 +105,7 @@ on:
           The output format of the scan results. If the format is 'sarif' (default), the results are automatically
           uploaded to GitHub code scanning. This input is ignored when a 'scan_config' is configured. Setting the
           'format' option in the scan config file has the same effect.
+          DEPRECATED: Use the scan config file and configure the 'format' option instead.
         type: string
         required: false
         default: sarif
@@ -110,6 +114,7 @@ on:
           The output template for the scan results - see https://github.com/aquasecurity/trivy-action#inputs (template).
           This input is ignored when a 'scan_config' is configured. Setting the 'template' option in the scan config
           file has the same effect.
+          DEPRECATED: Use the scan config file and configure the 'template' option instead.
         type: string
         required: false
       scan_severity:
@@ -117,6 +122,7 @@ on:
           The severities of security issues to be reported - see https://github.com/aquasecurity/trivy-action#inputs
           (severity). Defaults to 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'. This input is ignored when a 'scan_config' is
           configured. Setting the 'severity' option in the scan config file has the same effect.
+          DEPRECATED: Use the scan config file and configure the 'severity' option instead.
         type: string
         required: false
       scan_vuln_type:
@@ -124,6 +130,7 @@ on:
           The vulnerability types to be reported - see https://github.com/aquasecurity/trivy-action#inputs (vuln-type).
           This input is ignored when a 'scan_config' is configured. Setting the 'vulnerability.type' option in the scan
           config file has the same effect.
+          DEPRECATED: Use the scan config file and configure the 'vulnerability.type' option instead.
         type: string
         required: false
     secrets:

--- a/.github/workflows/trivy-image.yml
+++ b/.github/workflows/trivy-image.yml
@@ -3,17 +3,6 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-# This workflow can execute a Maven build that creates the Docker image that should be tested. But it assumes that all
-# required artifacts that are needed for the build are already cached and no downloads from a custom Maven repository
-# manager are required anymore.
-
-# ******** NOTE ********
-# The configuration of the trivy-action (and with that the configuration of THIS workflow) may not behave like expected,
-# because the implementation of the trivy-action takes some unpredictable precedences when working with combinations of
-# SARIF reports, Trivy config file and plain action input parameters. If you experience such unexpected behaviour with
-# your configuration, you may find hints how to solve it having a look at the implementation of the trivy-action,
-# especially https://github.com/aquasecurity/trivy-action/blob/0.11.0/entrypoint.sh#L175-L190.
-
 # Required permissions that must be set in caller workflows (in private repositories):
 # contents:         read      for actions/checkout to fetch code
 # security-events:  write     for github/codeql-action/upload-sarif to upload SARIF results
@@ -33,7 +22,9 @@ on:
         type: string
         required: false
       fail_on_issues:
-        description: Fail when vulnerabilities are found.
+        description: |
+          Fail when vulnerabilities are found. This input is ignored when a 'scan_config' is configured. Setting the
+          'exit-code' to 1 or higher in the scan config file has the same effect like 'fail_on_issues: true'.
         type: boolean
         required: false
         default: false
@@ -66,21 +57,30 @@ on:
           The path to a 'trivy.yaml' config file - see https://github.com/aquasecurity/trivy-action#inputs
           (trivy-config) and https://aquasecurity.github.io/trivy/latest/docs/references/configuration/config-file.
           Using a config file over action inputs provides more configuration options and may lead to cleaner workflow
-          code. A YAML contents of a basic config file may look like this:
-              severity:
-                - MEDIUM
-                - HIGH
-                - CRITICAL
-              vulnerability:
-                type:
-                  - library
-          Please also see the NOTE above to avoid problems due to unpredictable configuration precedences.
+          code. PLEASE NOTE that the trivy-action (and with that the configuration of THIS workflow) ignores the input
+          parameters for scan options when a scan config file is configured. Ensure that all required options are then
+          set in the scan config file. This is a basic scan config file reflecting the default input parameters (with
+          defaults commented out as they can be omitted):
+              format: sarif
+              output: trivy-results.sarif
+              #exit-code: 0
+              #severity:
+              #  - UNKNOWN
+              #  - LOW
+              #  - MEDIUM
+              #  - HIGH
+              #  - CRITICAL
+              #vulnerability:
+              #  type:
+              #    - os
+              #    - library
         type: string
         required: false
       scan_ignores:
         description: |
           Comma-separated list of relative paths in repository to one or more '.trivyignore' files - see 
-          https://github.com/aquasecurity/trivy-action#inputs (trivyignores).
+          https://github.com/aquasecurity/trivy-action#inputs (trivyignores). This input is ignored when a 'scan_config'
+          is configured. Setting the 'ignorefile' option in the scan config file has the same effect.
         type: string
         required: false
       scan_image_ref:
@@ -91,31 +91,39 @@ on:
         required: true
       scan_output_file:
         description: |
-          The output file for the scan results, - see https://github.com/aquasecurity/trivy-action#inputs (output).
-          When an output file be is configured, it will be attached to the workflow run.
+          The output file for the scan results, - see https://github.com/aquasecurity/trivy-action#inputs (output). The
+          Defaults to 'trivy-results.sarif' when the scan format is 'sarif'. This input is ignored when a 'scan_config'
+          is configured. Setting the 'output' option in the scan config file has the same effect. When an output file is
+          explicitly configured with this input, it will be attached to the workflow run.
         type: string
         required: false
       scan_output_format:
         description: |
           The output format of the scan results. If the format is 'sarif' (default), the results are automatically
-          uploaded to GitHub code scanning.
+          uploaded to GitHub code scanning. This input is ignored when a 'scan_config' is configured. Setting the
+          'format' option in the scan config file has the same effect.
         type: string
         required: false
         default: sarif
       scan_output_template:
         description: |
           The output template for the scan results - see https://github.com/aquasecurity/trivy-action#inputs (template).
+          This input is ignored when a 'scan_config' is configured. Setting the 'template' option in the scan config
+          file has the same effect.
         type: string
         required: false
       scan_severity:
         description: |
           The severities of security issues to be reported - see https://github.com/aquasecurity/trivy-action#inputs
-          (severity). Defaults to 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'.
+          (severity). Defaults to 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'. This input is ignored when a 'scan_config' is
+          configured. Setting the 'severity' option in the scan config file has the same effect.
         type: string
         required: false
       scan_vuln_type:
         description: |
           The vulnerability types to be reported - see https://github.com/aquasecurity/trivy-action#inputs (vuln-type).
+          This input is ignored when a 'scan_config' is configured. Setting the 'vulnerability.type' option in the scan
+          config file has the same effect.
         type: string
         required: false
     secrets:
@@ -167,7 +175,7 @@ jobs:
           if [[ -n '${{ inputs.scan_output_file }}' ]]; then
             echo 'output_file=${{ inputs.scan_output_file }}' >> "$GITHUB_OUTPUT"
           elif [[ '${{ inputs.scan_output_format }}' == 'sarif' ]]; then
-            echo 'output_file=trivy-image-results.sarif' >> "$GITHUB_OUTPUT"
+            echo 'output_file=trivy-results.sarif' >> "$GITHUB_OUTPUT"
           elif [[ '${{ inputs.scan_output_format }}' != 'table' ]]; then
             echo "::error title=Configuration Error::'scan_output_format=${{ inputs.scan_output_format }}' requires 'scan_output_file'."
             exit 1


### PR DESCRIPTION
[Bump aquasecurity/trivy-action from 0.11.0 to 0.11.2 \#17](https://github.com/CoreMedia/github-actions/pull/17) reverts the implementation that should allow using both, the config file and input parameters, because many other user ran into problems. Because of that, I had to rethink configurations:
* `limit-severities-for-sarif` is now always true and not configurable in our reusable workflow anymore. This prevents the [aquasecurity/trivy-action](https://github.com/aquasecurity/trivy-action) from going into the special implementation for SARIF with more or less unexpected behaviour. If someone wants such behaviour, it can always be configured manually.
* The documentation has been updated to clearly state the precedence of the config file over the input params.
* As working with both, input params and config file leads to cumbersome implementations, I decided to deprecate the input params that are covered by the config file options.

Tested with https://github.com/CoreMedia/coremedia-headless-commerce/pull/66 -> https://github.com/CoreMedia/coremedia-headless-commerce/actions/runs/5266256780/jobs/9524133784 -> https://github.com/CoreMedia/coremedia-headless-commerce/security/code-scanning?query=pr%3A66+tool%3ATrivy+is%3Aopen