### PR TITLE
Fix Nexus credentials error (COMHUB-229)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -143,14 +143,7 @@ jobs:
         with:
           java-version: ${{ inputs.java_version }}
           distribution: ${{ inputs.java_distribution }}
-
-      - name: Cache Maven Repo
-        if: ${{ !env.ACT && matrix.language == 'java' }}
-        uses: actions/cache@v3.3.1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven
+          cache: ${{ !env.ACT && 'maven' || '' }}
 
       - name: Overwrite Maven settings
         if: matrix.language == 'java' && inputs.maven_settings

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -149,8 +149,8 @@ jobs:
         uses: actions/cache@v3.3.1
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven
 
       - name: Overwrite Maven settings
         if: matrix.language == 'java' && inputs.maven_settings

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -144,10 +144,6 @@ jobs:
           java-version: ${{ inputs.java_version }}
           distribution: ${{ inputs.java_distribution }}
 
-      - name: Overwrite Maven settings
-        if: matrix.language == 'java' && inputs.maven_settings
-        run: cp ${{ inputs.maven_settings }} ${HOME}/.m2/settings.xml
-
       - name: Cache Maven Repo
         if: ${{ !env.ACT && matrix.language == 'java' }}
         uses: actions/cache@v3.3.1
@@ -155,6 +151,10 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
+
+      - name: Overwrite Maven settings
+        if: matrix.language == 'java' && inputs.maven_settings
+        run: cp ${{ inputs.maven_settings }} ${HOME}/.m2/settings.xml
 
       # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
       # If this step fails, then you should remove it and run the build manually

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -148,7 +148,7 @@ jobs:
         if: ${{ !env.ACT && matrix.language == 'java' }}
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.m2
+          path: ~/.m2/repository
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -108,8 +108,8 @@ jobs:
         uses: actions/cache@v3.3.1
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven
 
       - name: Overwrite Maven settings
         if: inputs.maven_settings

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -102,14 +102,7 @@ jobs:
           server-id: ${{ inputs.maven_repo_server_id }}
           server-username: MAVEN_REPO_USER
           server-password: MAVEN_REPO_PASSWORD
-
-      - name: Cache Maven Repo
-        if: ${{ !env.ACT }}
-        uses: actions/cache@v3.3.1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven
+          cache: ${{ !env.ACT && 'maven' || '' }}
 
       - name: Overwrite Maven settings
         if: inputs.maven_settings

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -103,10 +103,6 @@ jobs:
           server-username: MAVEN_REPO_USER
           server-password: MAVEN_REPO_PASSWORD
 
-      - name: Overwrite Maven settings
-        if: inputs.maven_settings
-        run: cp ${{ inputs.maven_settings }} ${HOME}/.m2/settings.xml
-
       - name: Cache Maven Repo
         if: ${{ !env.ACT }}
         uses: actions/cache@v3.3.1
@@ -114,6 +110,10 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
+
+      - name: Overwrite Maven settings
+        if: inputs.maven_settings
+        run: cp ${{ inputs.maven_settings }} ${HOME}/.m2/settings.xml
 
       - name: Run Maven Build
         run: ${{ inputs.maven_command }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -107,7 +107,7 @@ jobs:
         if: ${{ !env.ACT }}
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.m2
+          path: ~/.m2/repository
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 

--- a/.github/workflows/trivy-image.yml
+++ b/.github/workflows/trivy-image.yml
@@ -187,14 +187,7 @@ jobs:
         with:
           java-version: ${{ inputs.java_version }}
           distribution: ${{ inputs.java_distribution }}
-
-      - name: Cache Maven Repo
-        if: ${{ !env.ACT && startsWith(inputs.build_image_command, 'mvn') }}
-        uses: actions/cache@v3.3.1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven
+          cache: ${{ !env.ACT && 'maven' || '' }}
 
       - name: Overwrite Maven settings
         if: startsWith(inputs.build_image_command, 'mvn') && inputs.maven_settings

--- a/.github/workflows/trivy-image.yml
+++ b/.github/workflows/trivy-image.yml
@@ -192,7 +192,7 @@ jobs:
         if: ${{ !env.ACT && startsWith(inputs.build_image_command, 'mvn') }}
         uses: actions/cache@v3.3.1
         with:
-          path: ~/.m2
+          path: ~/.m2/repository
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 

--- a/.github/workflows/trivy-image.yml
+++ b/.github/workflows/trivy-image.yml
@@ -188,10 +188,6 @@ jobs:
           java-version: ${{ inputs.java_version }}
           distribution: ${{ inputs.java_distribution }}
 
-      - name: Overwrite Maven settings
-        if: startsWith(inputs.build_image_command, 'mvn') && inputs.maven_settings
-        run: cp ${{ inputs.maven_settings }} ${HOME}/.m2/settings.xml
-
       - name: Cache Maven Repo
         if: ${{ !env.ACT && startsWith(inputs.build_image_command, 'mvn') }}
         uses: actions/cache@v3.3.1
@@ -199,6 +195,10 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
+
+      - name: Overwrite Maven settings
+        if: startsWith(inputs.build_image_command, 'mvn') && inputs.maven_settings
+        run: cp ${{ inputs.maven_settings }} ${HOME}/.m2/settings.xml
 
       - name: Build Docker image with Maven
         if: startsWith(inputs.build_image_command, 'mvn')

--- a/.github/workflows/trivy-image.yml
+++ b/.github/workflows/trivy-image.yml
@@ -193,8 +193,8 @@ jobs:
         uses: actions/cache@v3.3.1
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven
 
       - name: Overwrite Maven settings
         if: startsWith(inputs.build_image_command, 'mvn') && inputs.maven_settings


### PR DESCRIPTION
The problem(s): The dir `~/.m2` was cached instead of `~/.m2/repository` and the cache was restored after the custom `settings.xml` was copied, hence the custom setting were always overwritten by the cache settings.

This PRs changes fix both of the above issues, furthermore it makes use of the `setup-java` actions' improved cache handling, where the cache archive cannot grow indefinitely.

Tested with:
* https://github.com/CoreMedia/coremedia-headless-commerce/actions/runs/5270355811
* https://github.com/CoreMedia/commerce-adapter-base/actions/runs/5270313364