### PR TITLE
Allow configuration of custom cache key prefix

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,8 +43,8 @@ on:
         default: 11
       java_distribution:
         description: |
-          The Java distribution to be used - https://github.com/actions/setup-java#usage (distribution). It's only used
-          when the language to be analysed is 'java'.
+          The Java distribution to be used - see https://github.com/actions/setup-java#usage (distribution). It's only
+          used when the language to be analysed is 'java'.
         type: string
         required: false
         default: corretto
@@ -55,6 +55,15 @@ on:
           https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/.
         type: string
         required: true
+      maven_cache_key_prefix:
+        description: |
+          A custom cache key prefix for the local Maven repository. By default, the workflow uses the optimized cache
+          implementation of the 'setup_java' action - see https://github.com/actions/setup-java#usage (cache). When
+          a custom cache key prefix is provided, it uses the 'cache' action directly and configures the key with the
+          custom prefix instead of the 'setup-java' prefix - https://github.com/actions/cache#inputs (key). Please note
+          that no 'restore-keys' optimization applies in this case.
+        type: string
+        required: false
       maven_settings:
         description: |
           The (user) 'settings.xml' file to be used for the Maven build. Please note that environment variables
@@ -137,13 +146,20 @@ jobs:
           queries: ${{ inputs.queries }}
           config-file: ${{ inputs.config_file }}
 
-      - name: Set up JDK 11
+      - name: Set up JDK
         if: matrix.language == 'java'
         uses: actions/setup-java@v3.11.0
         with:
           java-version: ${{ inputs.java_version }}
           distribution: ${{ inputs.java_distribution }}
-          cache: ${{ !env.ACT && 'maven' || '' }}
+          cache: ${{ (!env.ACT && !inputs.maven_cache_key_prefix) && 'maven' || '' }}
+
+      - name: Cache Maven Repo with custom key (replacing cache from Set up JDK)
+        if: ${{ !env.ACT && inputs.maven_cache_key_prefix }}
+        uses: actions/cache@v3.3.1
+        with:
+          path: ~/.m2/repository
+          key: ${{ inputs.maven_cache_key_prefix }}-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
 
       - name: Overwrite Maven settings
         if: matrix.language == 'java' && inputs.maven_settings

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,10 +25,19 @@ on:
         required: false
         default: 11
       java_distribution:
-        description: The Java distribution to be used - https://github.com/actions/setup-java#usage (distribution).
+        description: The Java distribution to be used - see https://github.com/actions/setup-java#usage (distribution).
         type: string
         required: false
         default: corretto
+      maven_cache_key_prefix:
+        description: |
+          A custom cache key prefix for the local Maven repository. By default, the workflow uses the optimized cache
+          implementation of the 'setup_java' action - see https://github.com/actions/setup-java#usage (cache). When
+          a custom cache key prefix is provided, it uses the 'cache' action directly and configures the key with the
+          custom prefix instead of the 'setup-java' prefix - https://github.com/actions/cache#inputs (key). Please note
+          that no 'restore-keys' optimization applies in this case.
+        type: string
+        required: false
       maven_command:
         description: The Maven build command to be executed.
         type: string
@@ -94,7 +103,7 @@ jobs:
             echo "checkout_ref=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v3.11.0
         with:
           java-version: ${{ inputs.java_version }}
@@ -102,7 +111,14 @@ jobs:
           server-id: ${{ inputs.maven_repo_server_id }}
           server-username: MAVEN_REPO_USER
           server-password: MAVEN_REPO_PASSWORD
-          cache: ${{ !env.ACT && 'maven' || '' }}
+          cache: ${{ (!env.ACT && !inputs.maven_cache_key_prefix) && 'maven' || '' }}
+
+      - name: Cache Maven Repo with custom key (replacing cache from Set up JDK)
+        if: ${{ !env.ACT && inputs.maven_cache_key_prefix }}
+        uses: actions/cache@v3.3.1
+        with:
+          path: ~/.m2/repository
+          key: ${{ inputs.maven_cache_key_prefix }}-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
 
       - name: Overwrite Maven settings
         if: inputs.maven_settings

--- a/.github/workflows/trivy-image.yml
+++ b/.github/workflows/trivy-image.yml
@@ -38,11 +38,20 @@ on:
         default: 11
       java_distribution:
         description: |
-          The Java distribution to be used - https://github.com/actions/setup-java#usage (distribution). It's only used
-          when the 'image_build_command' starts with 'mvn'.
+          The Java distribution to be used - see https://github.com/actions/setup-java#usage (distribution). It's only
+          used when the 'image_build_command' starts with 'mvn'.
         type: string
         required: false
         default: corretto
+      maven_cache_key_prefix:
+        description: |
+          A custom cache key prefix for the local Maven repository. By default, the workflow uses the optimized cache
+          implementation of the 'setup_java' action - see https://github.com/actions/setup-java#usage (cache). When
+          a custom cache key prefix is provided, it uses the 'cache' action directly and configures the key with the
+          custom prefix instead of the 'setup-java' prefix - https://github.com/actions/cache#inputs (key). Please note
+          that no 'restore-keys' optimization applies in this case.
+        type: string
+        required: false
       maven_settings:
         description: |
           The (user) 'settings.xml' file to be used for the Maven build. Please note that environment variables
@@ -188,13 +197,20 @@ jobs:
             exit 1
           fi
 
-      - name: Set up JDK 11
+      - name: Set up JDK
         if: startsWith(inputs.build_image_command, 'mvn')
         uses: actions/setup-java@v3.11.0
         with:
           java-version: ${{ inputs.java_version }}
           distribution: ${{ inputs.java_distribution }}
-          cache: ${{ !env.ACT && 'maven' || '' }}
+          cache: ${{ (!env.ACT && !inputs.maven_cache_key_prefix) && 'maven' || '' }}
+
+      - name: Cache Maven Repo with custom key (replacing cache from Set up JDK)
+        if: ${{ !env.ACT && inputs.maven_cache_key_prefix }}
+        uses: actions/cache@v3.3.1
+        with:
+          path: ~/.m2/repository
+          key: ${{ inputs.maven_cache_key_prefix }}-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
 
       - name: Overwrite Maven settings
         if: startsWith(inputs.build_image_command, 'mvn') && inputs.maven_settings


### PR DESCRIPTION
Solves cache conflicts for the LC Connector's [Backward Compatibility Check](https://github.com/CoreMedia/lc-connector/actions/workflows/bc-check.yml), where different dependencies are downloaded for the same Maven POM like for the fault build.

See:
* [Compatibility check using custom cache key](https://github.com/CoreMedia/lc-connector/actions/runs/5443587950/jobs/9900296458#step:4:35)
* [Default pipeline using default cache](https://github.com/CoreMedia/lc-connector/actions/runs/5443587958/jobs/9900296615#step:4:39)