### PR TITLE
Avoid overwriting Maven settings when defaults are used (main)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -165,6 +165,11 @@ jobs:
         if: matrix.language == 'java' && inputs.maven_settings
         run: cp ${{ inputs.maven_settings }} ${HOME}/.m2/settings.xml
 
+      - name: Provide secrets to build environment
+        uses: oNaiPs/secrets-to-env-action@v1.3
+        with:
+          secrets: ${{ toJSON(secrets) }}
+
       # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
       # If this step fails, then you should remove it and run the build manually
       - name: Autobuild

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -66,14 +66,13 @@ on:
         required: false
       maven_settings:
         description: |
-          The (user) 'settings.xml' file to be used for the Maven build. Please note that environment variables
-          cannot be provided from the caller workflow. If environment variables with server credentials are
-          required by the provided 'settings.xml', they must be named 'MAVEN_REPO_USER' and 'MAVEN_REPO_PASSWORD'
-          and have to be set via workflow secrets 'maven_repo_user' and 'maven_repo_password'. It's only used when
-          the language to be analysed is 'java'.
+          The (user) 'settings.xml' file to be used for the Maven build. Environment variables for replacement tokens
+          (like '${env.MY_USERNAME}') in the 'settings.xml' can be provided as secrets with the same name. They will
+          internally be provided as environment variables to the build environment.
+          Hint: Use 'secrets: inherit' to provide the secrets from the caller workflow's repository settings to the
+          reusable workflow without having to map them one by one.
         type: string
         required: false
-        default: ''
       queries:
         description: |
           The CodeQL query suites to run - see https://github.com/github/codeql-action and

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -120,6 +120,11 @@ jobs:
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
+      - name: Provide secrets to build environment
+        uses: oNaiPs/secrets-to-env-action@v1.3
+        with:
+          secrets: ${{ toJSON(secrets) }}
+
       - name: Checkout repository
         uses: actions/checkout@v3.5.3
         with:
@@ -164,11 +169,6 @@ jobs:
       - name: Overwrite Maven settings
         if: matrix.language == 'java' && inputs.maven_settings
         run: cp ${{ inputs.maven_settings }} ${HOME}/.m2/settings.xml
-
-      - name: Provide secrets to build environment
-        uses: oNaiPs/secrets-to-env-action@v1.3
-        with:
-          secrets: ${{ toJSON(secrets) }}
 
       # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
       # If this step fails, then you should remove it and run the build manually

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -80,17 +80,6 @@ on:
           https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/customizing-code-scanning#using-queries-in-ql-packs
         type: string
         required: false
-    secrets:
-      maven_repo_user:
-        description: |
-          The user to connect to an additional Maven repository to download artifacts from. Will be set via
-          environment variable 'MAVEN_REPO_USER'. It's only used when the language to be analysed is 'java'.
-        required: false
-      maven_repo_password:
-        description: |
-          The password to connect to an additional Maven repository to download artifacts from. Will be set via
-          environment variable 'MAVEN_REPO_PASSWORD'. It's only used when the language to be analysed is 'java'.
-        required: false
     outputs:
       teams_fact_json:
         description: The 'fact' JSON snippet that can be added to an MS Teams Notification.
@@ -104,9 +93,6 @@ jobs:
   codeql:
     name: Analysis
     runs-on: ubuntu-latest
-    env:
-      MAVEN_REPO_USER: ${{ secrets.maven_repo_user }}
-      MAVEN_REPO_PASSWORD: ${{ secrets.maven_repo_password }}
     outputs:
       result: ${{ job.status }}
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -43,11 +43,6 @@ on:
         type: string
         required: false
         default: 'mvn --batch-mode install'
-      maven_repo_server_id:
-        description: The ID of an additional Maven repository to download artifacts from.
-        type: string
-        required: false
-        default: ''
       maven_settings:
         description: |
           The (user) 'settings.xml' file to be used for the Maven build. When provided, it will supersede the input
@@ -68,17 +63,6 @@ on:
         type: boolean
         required: false
         default: false
-    secrets:
-      maven_repo_user:
-        description: |
-          The user to connect to an additional Maven repository to download artifacts from. Will be set via
-          environment variable 'MAVEN_REPO_USER'.
-        required: false
-      maven_repo_password:
-        description: |
-          The password to connect to an additional Maven repository to download artifacts from. Will be set
-          via environment variable 'MAVEN_REPO_PASSWORD'.
-        required: false
     outputs:
       teams_fact_json:
         description: The 'fact' JSON snippet that can be added to an MS Teams Notification.
@@ -92,9 +76,6 @@ jobs:
   maven:
     name: Maven Build
     runs-on: ubuntu-latest
-    env:
-      MAVEN_REPO_USER: ${{ secrets.maven_repo_user }}
-      MAVEN_REPO_PASSWORD: ${{ secrets.maven_repo_password }}
     outputs:
       result: ${{ job.status }}
 
@@ -123,9 +104,6 @@ jobs:
         with:
           java-version: ${{ inputs.java_version }}
           distribution: ${{ inputs.java_distribution }}
-          server-id: ${{ inputs.maven_repo_server_id }}
-          server-username: MAVEN_REPO_USER
-          server-password: MAVEN_REPO_PASSWORD
           cache: ${{ (!env.ACT && !inputs.maven_cache_key_prefix) && 'maven' || '' }}
 
       - name: Cache Maven Repo with custom key (replacing cache from Set up JDK)

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -134,6 +134,11 @@ jobs:
         if: inputs.maven_settings
         run: cp ${{ inputs.maven_settings }} ${HOME}/.m2/settings.xml
 
+      - name: Provide secrets to build environment
+        uses: oNaiPs/secrets-to-env-action@v1.3
+        with:
+          secrets: ${{ toJSON(secrets) }}
+
       - name: Run Maven Build
         run: ${{ inputs.maven_command }}
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -99,6 +99,11 @@ jobs:
       result: ${{ job.status }}
 
     steps:
+      - name: Provide secrets to build environment
+        uses: oNaiPs/secrets-to-env-action@v1.3
+        with:
+          secrets: ${{ toJSON(secrets) }}
+
       - name: Checkout repository
         uses: actions/checkout@v3.5.3
         with:
@@ -133,11 +138,6 @@ jobs:
       - name: Overwrite Maven settings
         if: inputs.maven_settings
         run: cp ${{ inputs.maven_settings }} ${HOME}/.m2/settings.xml
-
-      - name: Provide secrets to build environment
-        uses: oNaiPs/secrets-to-env-action@v1.3
-        with:
-          secrets: ${{ toJSON(secrets) }}
 
       - name: Run Maven Build
         run: ${{ inputs.maven_command }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -45,14 +45,13 @@ on:
         default: 'mvn --batch-mode install'
       maven_settings:
         description: |
-          The (user) 'settings.xml' file to be used for the Maven build. When provided, it will supersede the input
-          'maven_repo_server_id'. Please note that environment variables cannot be provided from the caller workflow.
-          If environment variables with server credentials are required by the provided 'settings.xml', they must be
-          named 'MAVEN_REPO_USER' and 'MAVEN_REPO_PASSWORD' and have to be set via workflow secrets 'maven_repo_user'
-          and 'maven_repo_password'.
+          The (user) 'settings.xml' file to be used for the Maven build. Environment variables for replacement tokens
+          (like '${env.MY_USERNAME}') in the 'settings.xml' can be provided as secrets with the same name. They will
+          internally be provided as environment variables to the build environment.
+          Hint: Use 'secrets: inherit' to provide the secrets from the caller workflow's repository settings to the
+          reusable workflow without having to map them one by one.
         type: string
         required: false
-        default: ''
       skip_update_dependency_graph:
         description: |
           Allows to skip the upload of the full dependency graph to GitHub. By default, the full dependency graph is

--- a/.github/workflows/trivy-image.yml
+++ b/.github/workflows/trivy-image.yml
@@ -173,6 +173,11 @@ jobs:
       result: ${{ job.status }}
 
     steps:
+      - name: Provide secrets to build environment
+        uses: oNaiPs/secrets-to-env-action@v1.3
+        with:
+          secrets: ${{ toJSON(secrets) }}
+
       - name: Checkout repository
         uses: actions/checkout@v3.5.3
         with:
@@ -215,11 +220,6 @@ jobs:
       - name: Overwrite Maven settings
         if: startsWith(inputs.build_image_command, 'mvn') && inputs.maven_settings
         run: cp ${{ inputs.maven_settings }} ${HOME}/.m2/settings.xml
-
-      - name: Provide secrets to build environment
-        uses: oNaiPs/secrets-to-env-action@v1.3
-        with:
-          secrets: ${{ toJSON(secrets) }}
 
       - name: Build Docker image with Maven
         if: startsWith(inputs.build_image_command, 'mvn')

--- a/.github/workflows/trivy-image.yml
+++ b/.github/workflows/trivy-image.yml
@@ -216,6 +216,11 @@ jobs:
         if: startsWith(inputs.build_image_command, 'mvn') && inputs.maven_settings
         run: cp ${{ inputs.maven_settings }} ${HOME}/.m2/settings.xml
 
+      - name: Provide secrets to build environment
+        uses: oNaiPs/secrets-to-env-action@v1.3
+        with:
+          secrets: ${{ toJSON(secrets) }}
+
       - name: Build Docker image with Maven
         if: startsWith(inputs.build_image_command, 'mvn')
         run: ${{ inputs.build_image_command }}

--- a/.github/workflows/trivy-image.yml
+++ b/.github/workflows/trivy-image.yml
@@ -142,17 +142,6 @@ on:
           DEPRECATED: Use the scan config file and configure the 'vulnerability.type' option instead.
         type: string
         required: false
-    secrets:
-      maven_repo_user:
-        description: |
-          The user to connect to an additional Maven repository to download artifacts from. Will be set via
-          environment variable 'MAVEN_REPO_USER'. It's only used when the 'image_build_command' starts with 'mvn'.
-        required: false
-      maven_repo_password:
-        description: |
-          The password to connect to an additional Maven repository to download artifacts from. Will be set via
-          environment variable 'MAVEN_REPO_PASSWORD'. It's only used when the 'image_build_command' starts with 'mvn'.
-        required: false
     outputs:
       teams_fact_json:
         description: The 'fact' JSON snippet that can be added to an MS Teams Notification.
@@ -166,9 +155,6 @@ jobs:
   image:
     name: Image Scan
     runs-on: ubuntu-latest
-    env:
-      MAVEN_REPO_USER: ${{ secrets.maven_repo_user }}
-      MAVEN_REPO_PASSWORD: ${{ secrets.maven_repo_password }}
     outputs:
       result: ${{ job.status }}
 

--- a/.github/workflows/trivy-image.yml
+++ b/.github/workflows/trivy-image.yml
@@ -54,14 +54,13 @@ on:
         required: false
       maven_settings:
         description: |
-          The (user) 'settings.xml' file to be used for the Maven build. Please note that environment variables
-          cannot be provided from the caller workflow. If environment variables with server credentials are
-          required by the provided 'settings.xml', they must be named 'MAVEN_REPO_USER' and 'MAVEN_REPO_PASSWORD'
-          and have to be set via workflow secrets 'maven_repo_user' and 'maven_repo_password'. It's only used when
-          the 'image_build_command' starts with 'mvn'.
+          The (user) 'settings.xml' file to be used for the Maven build. Environment variables for replacement tokens
+          (like '${env.MY_USERNAME}') in the 'settings.xml' can be provided as secrets with the same name. They will
+          internally be provided as environment variables to the build environment.
+          Hint: Use 'secrets: inherit' to provide the secrets from the caller workflow's repository settings to the
+          reusable workflow without having to map them one by one.
         type: string
         required: false
-        default: ''
       scan_config:
         description: |
           The path to a 'trivy.yaml' config file - see https://github.com/aquasecurity/trivy-action#inputs


### PR DESCRIPTION
Before this change, custom Maven settings had to be provided although not needed. Now they can be omitted or if needed, secrets from repository settings can be provided/used without requiring one-by-one mapping. But it's **breaking**: retaining and supporting
all the old configurations would have made the workflow implementations more
cumbersome and errorprone - and as there're only usages in team-managed repos, I'm only planning a minor version update for this.

Successfully tested with:
* https://github.com/CoreMedia/coremedia-encryption/pull/17/commits/e64a31b3bb873148aecd86792e4be1c47311649b
* https://github.com/CoreMedia/coremedia-encryption/pull/17/commits/a3280bad8eba4f34c26faf133bedc98f5d34dba6
* https://github.com/CoreMedia/commerce-adapter-wcs/pull/401/commits/5c71664fce169ea09fad75d434f87eb53cd2f133