### PR TITLE
Change to only monthly updates of GitHub actions (main)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,6 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
-    reviewers:
-      - marcrohlfs
-      #- 'CoreMedia/ci-agents'
+    labels:
+      - dependencies
+      - toko

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,9 @@ updates:
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
-      interval: weekly
+      interval: monthly
+      time: '01:46'
+      timezone: 'Etc/UTC'
     labels:
       - dependencies
       - toko


### PR DESCRIPTION
autoclose none

FYI, @ClausMie: With @mkleine I decided that monthly updates for GitHub actions should be sufficient. There's no need to update them more often as they don't have (high) security implications. Updates just should be checked in the early mornings for all repositories so that they can be reviewed all at once. This will be a bigger effort once a month, but less cumulated effort than weekly updates.